### PR TITLE
Decompressors::GzipReader: fix open_stream close for nil stream

### DIFF
--- a/lib/register_common/decompressors/gzip_reader.rb
+++ b/lib/register_common/decompressors/gzip_reader.rb
@@ -9,7 +9,7 @@ module RegisterCommon
         gz = Zlib::GzipReader.new(stream)
         yield gz
       ensure
-        gz.close
+        gz&.close
       end
     end
   end


### PR DESCRIPTION
Otherwise, a failure in opening the stream will cause `gz` to be `nil`, causing `close` to fail. At the very least, this makes test failures from register-ingester-oc confusing, since

    #<Double "stream"> received unexpected message :readpartial with (2048)

or

    Zlib::GzipFile::Error: not in gzip format

are reported as failure

    undefined method `close' for nil:NilClass

instead.