### PR TITLE
[#171] add Utils::Object compact_deep

### DIFF
--- a/lib/register_common/utils/object.rb
+++ b/lib/register_common/utils/object.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module RegisterCommon
+  module Utils
+    module Object
+      # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+      def self.compact_deep(obj, prune: false)
+        obj2 = if obj.respond_to?(:transform_values)
+                 obj.transform_values { |v| compact_deep(v, prune:) }.compact
+               elsif obj.respond_to?(:map)
+                 obj.map { |e| compact_deep(e, prune:) }.compact
+               else
+                 obj
+               end
+        obj2 = nil if prune && obj.respond_to?(:empty?) && obj.empty?
+        obj2
+      end
+      # rubocop:enable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+    end
+  end
+end


### PR DESCRIPTION
This compacts an object, optionally pruning empty values such as empty hashes, empty arrays, or empty strings. This is useful when dealing with source data containing JSON null values, since the absence of a key is not the same as the presence of a key with a null value.

This was highlighted during work on importing AM data via static BODS.

---

References https://github.com/openownership/register/issues/171 .