### PR TITLE
[#217] change Redis connection to use URL

### DIFF
--- a/lib/register_common/adapters/redis_adapter.rb
+++ b/lib/register_common/adapters/redis_adapter.rb
@@ -5,8 +5,8 @@ require 'redis'
 module RegisterCommon
   module Adapters
     class RedisAdapter
-      def initialize(host:, port:)
-        @redis = Redis.new(host:, port:)
+      def initialize(url:)
+        @redis = Redis.new(url:)
       end
 
       def sismember(key, element)

--- a/lib/register_common/services/stream_client_kinesis.rb
+++ b/lib/register_common/services/stream_client_kinesis.rb
@@ -15,7 +15,7 @@ module RegisterCommon
         credentials:, stream_name:, msg_handler: nil, s3_adapter: nil, s3_bucket: nil, redis: nil,
         client: nil
       )
-        @redis = redis || Redis.new(host: ENV.fetch('REDIS_HOST', nil), port: ENV.fetch('REDIS_PORT', nil))
+        @redis = redis || Redis.new(url: ENV.fetch('REDIS_URL'))
         @msg_handler = msg_handler || MsgHandler.new(s3_adapter:, s3_bucket:)
         @client = client || Aws::Kinesis::Client.new(
           region: credentials.AWS_REGION,


### PR DESCRIPTION
Instead of REDIS_HOST, REDIS_PORT, use a single REDIS_URL variable. This is more in keeping with how Redis services are often deployed, and mirrors the change to ELASTICSEARCH_URL.

References https://github.com/openownership/register/issues/217 .