### PR TITLE
[#267] fix Adapters::S3Adapter list_objects limited to 1000 files

### DIFF
--- a/lib/register_common/adapters/s3_adapter.rb
+++ b/lib/register_common/adapters/s3_adapter.rb
@@ -53,12 +53,8 @@ module RegisterCommon
       end
 
       def list_objects(s3_bucket:, s3_prefix:)
-        s3_client.list_objects(
-          {
-            bucket: s3_bucket,
-            prefix: s3_prefix
-          }
-        ).contents.map(&:key)
+        s3_client.list_objects({ bucket: s3_bucket, prefix: s3_prefix })
+                 .flat_map { |res| res.contents.map(&:key) }
       end
 
       def create_multipart_upload(s3_bucket:, s3_path:)


### PR DESCRIPTION
`Adapters::S3Adapter` `list_objects` used the `AWS::S3` library incorrectly. If pagination is not handled explicitly, only the first 1000 items are returned.

Fix by iterating over all the results. Ideally, I would probably yield the results instead of flattening them for memory and performance reasons, but various other repos use this function with the expectation that it returns all the results. Rather than change each of them, I instead solve the issue within the function itself, leaving its signature as-is.

This is present in cff0bfeeb106a8d7ec166a83f97d18a3d4f918f5 , dating back to at least 6 Aug 2022.

References https://github.com/openownership/register/issues/267 .