### PR TITLE
Increase Athena timeout

### DIFF
--- a/lib/register_common/adapters/athena_adapter.rb
+++ b/lib/register_common/adapters/athena_adapter.rb
@@ -27,7 +27,7 @@ module RegisterCommon
         client.start_query_execution(params)
       end
 
-      def wait_for_query(execution_id, max_time: 100, wait_interval: 5)
+      def wait_for_query(execution_id, max_time: 1000, wait_interval: 5)
         max_time.times do
           query = get_query_execution(execution_id)
           return query if query.query_execution.status.state == 'SUCCEEDED'


### PR DESCRIPTION
Drastically increase Athena timeout, since we have a query running for longer than the expected waiting time.